### PR TITLE
Added support for trajectory output from waiting time processes

### DIFF
--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -320,7 +320,7 @@ def _progress_report(i, loop_length, msg=""):
         sys.stdout.write("\n")
         sys.stdout.flush()
 
-def equalize_time_series(dfi, N, t0=None, tN=None):
+def even_time_series_spacing(dfi, N, t0=None, tN=None):
     """
     interpolate irregularly spaced time series
     to obtain regularly spaced data.

--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -220,9 +220,11 @@ def resave_data(source_path, parameter_combinations, index, eva, name,
                 stackIndex = pd.MultiIndex(levels = stack.index.levels,\
                         labels = stack.index.labels,\
                         names = [u'timesteps', u'observables'])
-                eva_return = pd.DataFrame(stack, index = stackIndex)
-
-            df.loc[mx, evakey] = eva_return
+                eva_return = pd.DataFrame(stack, 
+                        index = stackIndex).sortlevel(level=1)
+                df.ix[mx, evakey] = eva_return[0].values
+            else:
+                df.loc[mx,evakey] = eva_return
 
     df.to_pickle(save_path + name)
 


### PR DESCRIPTION
Time series data from stochastic waiting time (e.g. poisson) processes usually is unevenly spaced.
Therefore, to be able to trivially average over these time series, I implemented a function (even_time_series_spacing()) to interpolate these time series and generate new data points that are regularly spaced in time.

``` python
def even_time_series_spacing(dfi, N, t0=None, tN=None):
    """
    interpolate irregularly spaced time series
    to obtain regularly spaced data.

    Parameters
    ----------
    dfi : pandas dataframe
        dataframe with one dimensional index containing
        time stamps as index values.
    N   : int
        number of regularly spaced timestamps in the
        resulting time series.
    t0  : float
        starting time of the resulting time series -
        defaults to the first time step of the input
        time series.
    tN  : float
        end time of the resulting time series -
        defaults to the last time step of the input
        time series.

    Returns
    -------
    dfo : pandas dataframe
        pandas dataframe with N regularly spaced 
        time steps starting at t0 and ending at tN
        inclusively. Output data is interpolated from 
        the input data.
    """
```

The output of this function already has the timesteps of the data points as their index values. therefore, I removed the check for 'time' as a column name from the resave_data method.
