### PR TITLE
Implemented experiment handling as class with native mpi4py dependency

### DIFF
--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -12,8 +12,12 @@ import itertools as it
 import mpi  # wrapper for mpi4py
 from scipy.interpolate import interp1d
 
-# TODO: make exp_handling as class / object to cache stuff like bad runs
+# TODO: 
+#------
+#make exp_handling as class / object to cache stuff like bad runs
 # -> suitable for multiple resavings
+
+#native implementation of mpi4py
 
 
 def compute(run_func, parameter_combinations, sample_size, save_path,

--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -90,8 +90,9 @@ def compute(run_func, parameter_combinations, sample_size, save_path,
             exit_status = run_func(*p, filename=save_path + _get_ID(p, s))
             if exit_status != 1:  # Checking for expected execution
                 # TODO: proper logging
-                print "!!! " + _get_ID(p, s) + " returned with: " \
-                    + str(exit_status)
+                #print "!!! " + _get_ID(p, s) + " returned with: " \
+                #    + str(exit_status)
+                pass
 
     mpi.run(verbose=0, master_func=master)
 
@@ -133,6 +134,7 @@ def resave_data(source_path, parameter_combinations, index, eva, name,
     """
     # add "/" to save_path if it does not end already with a "/"
     source_path += "/" if not source_path.endswith("/") else ""
+    save_path += "/" if not save_path.endswith("/") else ""
 
     # create save_path if it is not yet existing
     if not os.path.exists(save_path):
@@ -176,13 +178,10 @@ def resave_data(source_path, parameter_combinations, index, eva, name,
     input_is_dataframe = False
     if type(eva_return[0])==pd.core.frame.DataFrame and \
             not isinstance(eva_return[0].index, pd.core.index.MultiIndex):
-        print 'input is a trajectory'
         eff_params['timesteps'] = eva_return[0].index.values
         eff_params['observables'] = eva_return[0].columns.values
         index_order = list(it.chain.from_iterable([index.values(), ["timesteps", "observables"]]))
         input_is_dataframe = True
-    else:
-        print 'input is NOT a trajectory'
 
     
     #Create MultiIndex and Dataframe
@@ -232,8 +231,8 @@ def resave_data(source_path, parameter_combinations, index, eva, name,
 def find_bad_runs(save_path, missing_key=None):
     """
     Find model runs that did not exit properly. Such a "bad" run is 
-    characterized by fewer entries in the saved data dictionary. It is assumend
-    that at least one run was not bad, i.e. at least one data dicitonary has
+    characterized by fewer entries in the saved data dictionary. It is assumed
+    that at least one run was not bad, i.e. at least one data dictionary has
     more entries than bad runs.
 
     Parameters
@@ -253,6 +252,8 @@ def find_bad_runs(save_path, missing_key=None):
     """
     # add "/" to save_path if it does not end already with a "/"
     save_path += "/" if not save_path.endswith("/") else ""
+
+    #create list of all files in save_path/*
     d = glob.glob("{}*".format(save_path))
 
     runs = {}
@@ -260,6 +261,7 @@ def find_bad_runs(save_path, missing_key=None):
     for i, f in enumerate(d):
         _progress_report(i, len(d), "Collecting bad runs ...")
         resdic = np.load(f)
+        #extract the ID from the filename string of the form path/ID.pkl
         ID = f[f.rfind("/")+1:-4]
 
         if missing_key is None:

--- a/pymofa/experiment_visualization.py
+++ b/pymofa/experiment_visualization.py
@@ -10,7 +10,7 @@ mpl.style.use("ggplot")
 
 
 def explore_Parameterspace(TwoDFrame, title="",
-                           cmap='RdBu', vmin=None, vmax=None):
+                           cmap='RdBu', norm=None, vmin=None, vmax=None):
     """
     Explore variables in a 2-dim Parameterspace
 
@@ -41,7 +41,7 @@ def explore_Parameterspace(TwoDFrame, title="",
 
     X, Y = _create_meshgrid(xparams, yparams)
     fig = plt.figure()
-    c = plt.pcolormesh(X, Y, values, cmap=cmap, vmin=vmin, vmax=vmax)
+    c = plt.pcolormesh(X, Y, values, cmap=cmap, norm=norm, vmin=vmin, vmax=vmax)
     plt.colorbar(c, orientation="vertical")
     plt.xlim(np.min(X), np.max(X))
     plt.ylim(np.min(Y), np.max(Y))


### PR DESCRIPTION
I implemented a class for the experiment handling methods.
I also implemented native mpi4py usage for compute and resave routines.
I stripped the bad runs management by just rerunning parameter combinations, when they turned out bad.

parallel implementation of resaving is only useful for large sample sizes due to communication overhead. For smaller sample sizes, a serial implementation might actually be smarter.

Note, that any return values > 0 of the run_func is counted as good run. Only negative return values are counted as bad runs.

Usage is as follows:

``` python
#initiate handle instance with experiment variables
handle = eh(SAMPLE_SIZE, PARAM_COMBS, INDEX, SAVE_PATH_RAW, SAVE_PATH_RES)
#run computations on experiment variables
handle.compute(RUN_FUNC)
#post process the results of the computations. results go to SAVE_PATH_RES+NAME
handle.resave(EVA,NAME)
```
