### PR TITLE
another breaking change with `pandas>=2.0.0`

### DIFF
--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -362,7 +362,7 @@ class experiment_handling(object):
                                                           fnames=fnames,
                                                           process_df=process_df)
                     if not no_output:
-                        df = df.append(other=eva_return, verify_integrity=True)
+                        df = pd.concat([df, eva_return], verify_integrity=True)
 
             # If nodes are available, distribute work amongst nodes.
 
@@ -387,7 +387,7 @@ class experiment_handling(object):
                 elif tag == tags.DONE:
                     (mx, key, eva_return) = data
                     if not no_output:
-                        df = df.append(eva_return)
+                        df = pd.concat([df, eva_return], verify_integrity=True)
                     tasks_completed += 1
                     self._progress_report(tasks_completed, n_tasks,
                                           "Post-processing...")


### PR DESCRIPTION
Hi!

I have recently been starting to get `pik-copan/MayaSim` going again and therefore used `pymofa`. With latest versions of `pandas` (namely `pandas>=2.0.0`) I encountered another breaking change: `pandas.DataFrame.append()` has been removed and should be substituted by `pandas.DataFrame.concat()`. 

I updated `pymofa.experiment_handling` accordingly and it worked for my purposes, so I thought a pull request might be helpful. Let me know if there are any problems with it!

Best, Fritz