### PR TITLE
added .pkl to results file

### DIFF
--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -396,7 +396,7 @@ class experiment_handling(object):
             if not no_output:
                 df = df.unstack(level='key')
                 df.columns = df.columns.droplevel()
-                df.to_pickle(self.path_res + name)
+                df.to_pickle(self.path_res + name + '.pkl')
             print('\nDone')
 
         if self.amNode:

--- a/pymofa/experiment_handling.py
+++ b/pymofa/experiment_handling.py
@@ -362,7 +362,7 @@ class experiment_handling(object):
                                                           fnames=fnames,
                                                           process_df=process_df)
                     if not no_output:
-                        df = df.append(other=eva_return, verify_integrity=True)
+                        df = pd.concat([df, eva_return], verify_integrity=True)
 
             # If nodes are available, distribute work amongst nodes.
 
@@ -387,7 +387,7 @@ class experiment_handling(object):
                 elif tag == tags.DONE:
                     (mx, key, eva_return) = data
                     if not no_output:
-                        df = df.append(eva_return)
+                        df = pd.concat([df, eva_return], verify_integrity=True)
                     tasks_completed += 1
                     self._progress_report(tasks_completed, n_tasks,
                                           "Post-processing...")


### PR DESCRIPTION
Hi again!

While I was at it, I noticed that the output pickle file for the results is saved without a '.pkl' ending. It made sense to me to add that in `pymofa.experiment_handling.resave` so I could easily identify it as a pickle. Other people using pymofa might have to change their evaluation code for that though, so not sure if it makes sense to merge. Still wanted to contribute just in case. 

Best, Fritz

